### PR TITLE
Fix TP Handling for Simon Stores

### DIFF
--- a/Assets/SimonStoresScript.cs
+++ b/Assets/SimonStoresScript.cs
@@ -2736,6 +2736,8 @@ public class SimonStoresScript : MonoBehaviour
             yield break;
 
         yield return null;
+        yield return "strike";
+        yield return "solve";
         yield return m.Groups[1].Value
             .Select(ch =>
             {


### PR DESCRIPTION
Add "yield return strike" and "yield return solve" mainly due to animation of said module